### PR TITLE
Allow Nullptrs according to MPI Spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,12 @@ The `empi/empi` package has methods to support use of MPI in emergent simulation
 * Gathering `etable.Table` and `etensor.Tensor` data across processors.
 
 * A version of env.FixedTable that divides rows of table across MPI processors.
+
+## Development
+
+After updating any of the template files, you need to update the generated go files like so:
+```bash
+cd mpi
+go install github.com/apache/arrow/go/arrow/_tools/tmpl
+go generate
+```

--- a/mpi/dummy.gen.go
+++ b/mpi/dummy.gen.go
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !mpi
+//go:build !mpi
 
 package mpi
 

--- a/mpi/dummy.gen.go.tmpl
+++ b/mpi/dummy.gen.go.tmpl
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build !mpi
+//go:build !mpi
 
 package mpi
 

--- a/mpi/numeric.gen.go
+++ b/mpi/numeric.gen.go
@@ -4,7 +4,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build mpi
+//go:build mpi
 
 package mpi
 
@@ -53,10 +53,13 @@ func (cm *Comm) BcastF64(fmProc int, vals []float64) error {
 }
 
 // ReduceF64 reduces all values across procs to toProc in orig to dest using given operation.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ReduceF64(toProc int, op Op, dest, orig []float64) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Reduce(sendbuf, recvbuf, C.int(len(dest)), C.FLOAT64, op.ToC(), C.int(toProc), cm.comm), "ReduceF64")
 }
 
@@ -70,10 +73,13 @@ func (cm *Comm) AllReduceF64(op Op, dest, orig []float64) error {
 
 // GatherF64 gathers values from all procs into toProc proc, tiled into dest of size np * len(orig).
 // This is inverse of Scatter.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices.
 func (cm *Comm) GatherF64(toProc int, dest, orig []float64) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Gather(sendbuf, C.int(len(orig)), C.FLOAT64, recvbuf, C.int(len(orig)), C.FLOAT64, C.int(toProc), cm.comm), "GatherF64")
 }
 
@@ -88,9 +94,12 @@ func (cm *Comm) AllGatherF64(dest, orig []float64) error {
 
 // ScatterF64 scatters values from fmProc to all procs, distributing len(dest) size chunks to
 // each proc from orig slice, which must be of size np * len(dest).  This is inverse of Gather.
+// sendbuf is ignored on all procs except fmProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ScatterF64(fmProc int, dest, orig []float64) error {
-	sendbuf := unsafe.Pointer(&orig[0])
+	if sendbuf != nil {
+		sendbuf := unsafe.Pointer(&orig[0])
+	}
 	recvbuf := unsafe.Pointer(&dest[0])
 	return Error(C.MPI_Scatter(sendbuf, C.int(len(dest)), C.FLOAT64, recvbuf, C.int(len(dest)), C.FLOAT64, C.int(fmProc), cm.comm), "GatherF64")
 }
@@ -117,10 +126,13 @@ func (cm *Comm) BcastF32(fmProc int, vals []float32) error {
 }
 
 // ReduceF32 reduces all values across procs to toProc in orig to dest using given operation.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ReduceF32(toProc int, op Op, dest, orig []float32) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Reduce(sendbuf, recvbuf, C.int(len(dest)), C.FLOAT32, op.ToC(), C.int(toProc), cm.comm), "ReduceF32")
 }
 
@@ -134,10 +146,13 @@ func (cm *Comm) AllReduceF32(op Op, dest, orig []float32) error {
 
 // GatherF32 gathers values from all procs into toProc proc, tiled into dest of size np * len(orig).
 // This is inverse of Scatter.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices.
 func (cm *Comm) GatherF32(toProc int, dest, orig []float32) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Gather(sendbuf, C.int(len(orig)), C.FLOAT32, recvbuf, C.int(len(orig)), C.FLOAT32, C.int(toProc), cm.comm), "GatherF32")
 }
 
@@ -152,9 +167,12 @@ func (cm *Comm) AllGatherF32(dest, orig []float32) error {
 
 // ScatterF32 scatters values from fmProc to all procs, distributing len(dest) size chunks to
 // each proc from orig slice, which must be of size np * len(dest).  This is inverse of Gather.
+// sendbuf is ignored on all procs except fmProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ScatterF32(fmProc int, dest, orig []float32) error {
-	sendbuf := unsafe.Pointer(&orig[0])
+	if sendbuf != nil {
+		sendbuf := unsafe.Pointer(&orig[0])
+	}
 	recvbuf := unsafe.Pointer(&dest[0])
 	return Error(C.MPI_Scatter(sendbuf, C.int(len(dest)), C.FLOAT32, recvbuf, C.int(len(dest)), C.FLOAT32, C.int(fmProc), cm.comm), "GatherF32")
 }
@@ -181,10 +199,13 @@ func (cm *Comm) BcastInt(fmProc int, vals []int) error {
 }
 
 // ReduceInt reduces all values across procs to toProc in orig to dest using given operation.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ReduceInt(toProc int, op Op, dest, orig []int) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Reduce(sendbuf, recvbuf, C.int(len(dest)), C.INT64, op.ToC(), C.int(toProc), cm.comm), "ReduceInt")
 }
 
@@ -198,10 +219,13 @@ func (cm *Comm) AllReduceInt(op Op, dest, orig []int) error {
 
 // GatherInt gathers values from all procs into toProc proc, tiled into dest of size np * len(orig).
 // This is inverse of Scatter.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices.
 func (cm *Comm) GatherInt(toProc int, dest, orig []int) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Gather(sendbuf, C.int(len(orig)), C.INT64, recvbuf, C.int(len(orig)), C.INT64, C.int(toProc), cm.comm), "GatherInt")
 }
 
@@ -216,9 +240,12 @@ func (cm *Comm) AllGatherInt(dest, orig []int) error {
 
 // ScatterInt scatters values from fmProc to all procs, distributing len(dest) size chunks to
 // each proc from orig slice, which must be of size np * len(dest).  This is inverse of Gather.
+// sendbuf is ignored on all procs except fmProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ScatterInt(fmProc int, dest, orig []int) error {
-	sendbuf := unsafe.Pointer(&orig[0])
+	if sendbuf != nil {
+		sendbuf := unsafe.Pointer(&orig[0])
+	}
 	recvbuf := unsafe.Pointer(&dest[0])
 	return Error(C.MPI_Scatter(sendbuf, C.int(len(dest)), C.INT64, recvbuf, C.int(len(dest)), C.INT64, C.int(fmProc), cm.comm), "GatherInt")
 }
@@ -245,10 +272,13 @@ func (cm *Comm) BcastI64(fmProc int, vals []int64) error {
 }
 
 // ReduceI64 reduces all values across procs to toProc in orig to dest using given operation.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ReduceI64(toProc int, op Op, dest, orig []int64) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Reduce(sendbuf, recvbuf, C.int(len(dest)), C.INT64, op.ToC(), C.int(toProc), cm.comm), "ReduceI64")
 }
 
@@ -262,10 +292,13 @@ func (cm *Comm) AllReduceI64(op Op, dest, orig []int64) error {
 
 // GatherI64 gathers values from all procs into toProc proc, tiled into dest of size np * len(orig).
 // This is inverse of Scatter.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices.
 func (cm *Comm) GatherI64(toProc int, dest, orig []int64) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Gather(sendbuf, C.int(len(orig)), C.INT64, recvbuf, C.int(len(orig)), C.INT64, C.int(toProc), cm.comm), "GatherI64")
 }
 
@@ -280,9 +313,12 @@ func (cm *Comm) AllGatherI64(dest, orig []int64) error {
 
 // ScatterI64 scatters values from fmProc to all procs, distributing len(dest) size chunks to
 // each proc from orig slice, which must be of size np * len(dest).  This is inverse of Gather.
+// sendbuf is ignored on all procs except fmProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ScatterI64(fmProc int, dest, orig []int64) error {
-	sendbuf := unsafe.Pointer(&orig[0])
+	if sendbuf != nil {
+		sendbuf := unsafe.Pointer(&orig[0])
+	}
 	recvbuf := unsafe.Pointer(&dest[0])
 	return Error(C.MPI_Scatter(sendbuf, C.int(len(dest)), C.INT64, recvbuf, C.int(len(dest)), C.INT64, C.int(fmProc), cm.comm), "GatherI64")
 }
@@ -309,10 +345,13 @@ func (cm *Comm) BcastU64(fmProc int, vals []uint64) error {
 }
 
 // ReduceU64 reduces all values across procs to toProc in orig to dest using given operation.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ReduceU64(toProc int, op Op, dest, orig []uint64) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Reduce(sendbuf, recvbuf, C.int(len(dest)), C.UINT64, op.ToC(), C.int(toProc), cm.comm), "ReduceU64")
 }
 
@@ -326,10 +365,13 @@ func (cm *Comm) AllReduceU64(op Op, dest, orig []uint64) error {
 
 // GatherU64 gathers values from all procs into toProc proc, tiled into dest of size np * len(orig).
 // This is inverse of Scatter.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices.
 func (cm *Comm) GatherU64(toProc int, dest, orig []uint64) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Gather(sendbuf, C.int(len(orig)), C.UINT64, recvbuf, C.int(len(orig)), C.UINT64, C.int(toProc), cm.comm), "GatherU64")
 }
 
@@ -344,9 +386,12 @@ func (cm *Comm) AllGatherU64(dest, orig []uint64) error {
 
 // ScatterU64 scatters values from fmProc to all procs, distributing len(dest) size chunks to
 // each proc from orig slice, which must be of size np * len(dest).  This is inverse of Gather.
+// sendbuf is ignored on all procs except fmProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ScatterU64(fmProc int, dest, orig []uint64) error {
-	sendbuf := unsafe.Pointer(&orig[0])
+	if sendbuf != nil {
+		sendbuf := unsafe.Pointer(&orig[0])
+	}
 	recvbuf := unsafe.Pointer(&dest[0])
 	return Error(C.MPI_Scatter(sendbuf, C.int(len(dest)), C.UINT64, recvbuf, C.int(len(dest)), C.UINT64, C.int(fmProc), cm.comm), "GatherU64")
 }
@@ -373,10 +418,13 @@ func (cm *Comm) BcastI32(fmProc int, vals []int32) error {
 }
 
 // ReduceI32 reduces all values across procs to toProc in orig to dest using given operation.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ReduceI32(toProc int, op Op, dest, orig []int32) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Reduce(sendbuf, recvbuf, C.int(len(dest)), C.INT32, op.ToC(), C.int(toProc), cm.comm), "ReduceI32")
 }
 
@@ -390,10 +438,13 @@ func (cm *Comm) AllReduceI32(op Op, dest, orig []int32) error {
 
 // GatherI32 gathers values from all procs into toProc proc, tiled into dest of size np * len(orig).
 // This is inverse of Scatter.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices.
 func (cm *Comm) GatherI32(toProc int, dest, orig []int32) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Gather(sendbuf, C.int(len(orig)), C.INT32, recvbuf, C.int(len(orig)), C.INT32, C.int(toProc), cm.comm), "GatherI32")
 }
 
@@ -408,9 +459,12 @@ func (cm *Comm) AllGatherI32(dest, orig []int32) error {
 
 // ScatterI32 scatters values from fmProc to all procs, distributing len(dest) size chunks to
 // each proc from orig slice, which must be of size np * len(dest).  This is inverse of Gather.
+// sendbuf is ignored on all procs except fmProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ScatterI32(fmProc int, dest, orig []int32) error {
-	sendbuf := unsafe.Pointer(&orig[0])
+	if sendbuf != nil {
+		sendbuf := unsafe.Pointer(&orig[0])
+	}
 	recvbuf := unsafe.Pointer(&dest[0])
 	return Error(C.MPI_Scatter(sendbuf, C.int(len(dest)), C.INT32, recvbuf, C.int(len(dest)), C.INT32, C.int(fmProc), cm.comm), "GatherI32")
 }
@@ -437,10 +491,13 @@ func (cm *Comm) BcastU32(fmProc int, vals []uint32) error {
 }
 
 // ReduceU32 reduces all values across procs to toProc in orig to dest using given operation.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ReduceU32(toProc int, op Op, dest, orig []uint32) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Reduce(sendbuf, recvbuf, C.int(len(dest)), C.UINT32, op.ToC(), C.int(toProc), cm.comm), "ReduceU32")
 }
 
@@ -454,10 +511,13 @@ func (cm *Comm) AllReduceU32(op Op, dest, orig []uint32) error {
 
 // GatherU32 gathers values from all procs into toProc proc, tiled into dest of size np * len(orig).
 // This is inverse of Scatter.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices.
 func (cm *Comm) GatherU32(toProc int, dest, orig []uint32) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Gather(sendbuf, C.int(len(orig)), C.UINT32, recvbuf, C.int(len(orig)), C.UINT32, C.int(toProc), cm.comm), "GatherU32")
 }
 
@@ -472,9 +532,12 @@ func (cm *Comm) AllGatherU32(dest, orig []uint32) error {
 
 // ScatterU32 scatters values from fmProc to all procs, distributing len(dest) size chunks to
 // each proc from orig slice, which must be of size np * len(dest).  This is inverse of Gather.
+// sendbuf is ignored on all procs except fmProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ScatterU32(fmProc int, dest, orig []uint32) error {
-	sendbuf := unsafe.Pointer(&orig[0])
+	if sendbuf != nil {
+		sendbuf := unsafe.Pointer(&orig[0])
+	}
 	recvbuf := unsafe.Pointer(&dest[0])
 	return Error(C.MPI_Scatter(sendbuf, C.int(len(dest)), C.UINT32, recvbuf, C.int(len(dest)), C.UINT32, C.int(fmProc), cm.comm), "GatherU32")
 }
@@ -501,10 +564,13 @@ func (cm *Comm) BcastI16(fmProc int, vals []int16) error {
 }
 
 // ReduceI16 reduces all values across procs to toProc in orig to dest using given operation.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ReduceI16(toProc int, op Op, dest, orig []int16) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Reduce(sendbuf, recvbuf, C.int(len(dest)), C.INT16, op.ToC(), C.int(toProc), cm.comm), "ReduceI16")
 }
 
@@ -518,10 +584,13 @@ func (cm *Comm) AllReduceI16(op Op, dest, orig []int16) error {
 
 // GatherI16 gathers values from all procs into toProc proc, tiled into dest of size np * len(orig).
 // This is inverse of Scatter.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices.
 func (cm *Comm) GatherI16(toProc int, dest, orig []int16) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Gather(sendbuf, C.int(len(orig)), C.INT16, recvbuf, C.int(len(orig)), C.INT16, C.int(toProc), cm.comm), "GatherI16")
 }
 
@@ -536,9 +605,12 @@ func (cm *Comm) AllGatherI16(dest, orig []int16) error {
 
 // ScatterI16 scatters values from fmProc to all procs, distributing len(dest) size chunks to
 // each proc from orig slice, which must be of size np * len(dest).  This is inverse of Gather.
+// sendbuf is ignored on all procs except fmProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ScatterI16(fmProc int, dest, orig []int16) error {
-	sendbuf := unsafe.Pointer(&orig[0])
+	if sendbuf != nil {
+		sendbuf := unsafe.Pointer(&orig[0])
+	}
 	recvbuf := unsafe.Pointer(&dest[0])
 	return Error(C.MPI_Scatter(sendbuf, C.int(len(dest)), C.INT16, recvbuf, C.int(len(dest)), C.INT16, C.int(fmProc), cm.comm), "GatherI16")
 }
@@ -565,10 +637,13 @@ func (cm *Comm) BcastU16(fmProc int, vals []uint16) error {
 }
 
 // ReduceU16 reduces all values across procs to toProc in orig to dest using given operation.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ReduceU16(toProc int, op Op, dest, orig []uint16) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Reduce(sendbuf, recvbuf, C.int(len(dest)), C.UINT16, op.ToC(), C.int(toProc), cm.comm), "ReduceU16")
 }
 
@@ -582,10 +657,13 @@ func (cm *Comm) AllReduceU16(op Op, dest, orig []uint16) error {
 
 // GatherU16 gathers values from all procs into toProc proc, tiled into dest of size np * len(orig).
 // This is inverse of Scatter.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices.
 func (cm *Comm) GatherU16(toProc int, dest, orig []uint16) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Gather(sendbuf, C.int(len(orig)), C.UINT16, recvbuf, C.int(len(orig)), C.UINT16, C.int(toProc), cm.comm), "GatherU16")
 }
 
@@ -600,9 +678,12 @@ func (cm *Comm) AllGatherU16(dest, orig []uint16) error {
 
 // ScatterU16 scatters values from fmProc to all procs, distributing len(dest) size chunks to
 // each proc from orig slice, which must be of size np * len(dest).  This is inverse of Gather.
+// sendbuf is ignored on all procs except fmProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ScatterU16(fmProc int, dest, orig []uint16) error {
-	sendbuf := unsafe.Pointer(&orig[0])
+	if sendbuf != nil {
+		sendbuf := unsafe.Pointer(&orig[0])
+	}
 	recvbuf := unsafe.Pointer(&dest[0])
 	return Error(C.MPI_Scatter(sendbuf, C.int(len(dest)), C.UINT16, recvbuf, C.int(len(dest)), C.UINT16, C.int(fmProc), cm.comm), "GatherU16")
 }
@@ -629,10 +710,13 @@ func (cm *Comm) BcastI8(fmProc int, vals []int8) error {
 }
 
 // ReduceI8 reduces all values across procs to toProc in orig to dest using given operation.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ReduceI8(toProc int, op Op, dest, orig []int8) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Reduce(sendbuf, recvbuf, C.int(len(dest)), C.BYTE, op.ToC(), C.int(toProc), cm.comm), "ReduceI8")
 }
 
@@ -646,10 +730,13 @@ func (cm *Comm) AllReduceI8(op Op, dest, orig []int8) error {
 
 // GatherI8 gathers values from all procs into toProc proc, tiled into dest of size np * len(orig).
 // This is inverse of Scatter.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices.
 func (cm *Comm) GatherI8(toProc int, dest, orig []int8) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Gather(sendbuf, C.int(len(orig)), C.BYTE, recvbuf, C.int(len(orig)), C.BYTE, C.int(toProc), cm.comm), "GatherI8")
 }
 
@@ -664,9 +751,12 @@ func (cm *Comm) AllGatherI8(dest, orig []int8) error {
 
 // ScatterI8 scatters values from fmProc to all procs, distributing len(dest) size chunks to
 // each proc from orig slice, which must be of size np * len(dest).  This is inverse of Gather.
+// sendbuf is ignored on all procs except fmProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ScatterI8(fmProc int, dest, orig []int8) error {
-	sendbuf := unsafe.Pointer(&orig[0])
+	if sendbuf != nil {
+		sendbuf := unsafe.Pointer(&orig[0])
+	}
 	recvbuf := unsafe.Pointer(&dest[0])
 	return Error(C.MPI_Scatter(sendbuf, C.int(len(dest)), C.BYTE, recvbuf, C.int(len(dest)), C.BYTE, C.int(fmProc), cm.comm), "GatherI8")
 }
@@ -693,10 +783,13 @@ func (cm *Comm) BcastU8(fmProc int, vals []uint8) error {
 }
 
 // ReduceU8 reduces all values across procs to toProc in orig to dest using given operation.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ReduceU8(toProc int, op Op, dest, orig []uint8) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Reduce(sendbuf, recvbuf, C.int(len(dest)), C.BYTE, op.ToC(), C.int(toProc), cm.comm), "ReduceU8")
 }
 
@@ -710,10 +803,13 @@ func (cm *Comm) AllReduceU8(op Op, dest, orig []uint8) error {
 
 // GatherU8 gathers values from all procs into toProc proc, tiled into dest of size np * len(orig).
 // This is inverse of Scatter.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices.
 func (cm *Comm) GatherU8(toProc int, dest, orig []uint8) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Gather(sendbuf, C.int(len(orig)), C.BYTE, recvbuf, C.int(len(orig)), C.BYTE, C.int(toProc), cm.comm), "GatherU8")
 }
 
@@ -728,9 +824,12 @@ func (cm *Comm) AllGatherU8(dest, orig []uint8) error {
 
 // ScatterU8 scatters values from fmProc to all procs, distributing len(dest) size chunks to
 // each proc from orig slice, which must be of size np * len(dest).  This is inverse of Gather.
+// sendbuf is ignored on all procs except fmProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ScatterU8(fmProc int, dest, orig []uint8) error {
-	sendbuf := unsafe.Pointer(&orig[0])
+	if sendbuf != nil {
+		sendbuf := unsafe.Pointer(&orig[0])
+	}
 	recvbuf := unsafe.Pointer(&dest[0])
 	return Error(C.MPI_Scatter(sendbuf, C.int(len(dest)), C.BYTE, recvbuf, C.int(len(dest)), C.BYTE, C.int(fmProc), cm.comm), "GatherU8")
 }
@@ -757,10 +856,13 @@ func (cm *Comm) BcastC128(fmProc int, vals []complex128) error {
 }
 
 // ReduceC128 reduces all values across procs to toProc in orig to dest using given operation.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ReduceC128(toProc int, op Op, dest, orig []complex128) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Reduce(sendbuf, recvbuf, C.int(len(dest)), C.COMPLEX128, op.ToC(), C.int(toProc), cm.comm), "ReduceC128")
 }
 
@@ -774,10 +876,13 @@ func (cm *Comm) AllReduceC128(op Op, dest, orig []complex128) error {
 
 // GatherC128 gathers values from all procs into toProc proc, tiled into dest of size np * len(orig).
 // This is inverse of Scatter.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices.
 func (cm *Comm) GatherC128(toProc int, dest, orig []complex128) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Gather(sendbuf, C.int(len(orig)), C.COMPLEX128, recvbuf, C.int(len(orig)), C.COMPLEX128, C.int(toProc), cm.comm), "GatherC128")
 }
 
@@ -792,9 +897,12 @@ func (cm *Comm) AllGatherC128(dest, orig []complex128) error {
 
 // ScatterC128 scatters values from fmProc to all procs, distributing len(dest) size chunks to
 // each proc from orig slice, which must be of size np * len(dest).  This is inverse of Gather.
+// sendbuf is ignored on all procs except fmProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ScatterC128(fmProc int, dest, orig []complex128) error {
-	sendbuf := unsafe.Pointer(&orig[0])
+	if sendbuf != nil {
+		sendbuf := unsafe.Pointer(&orig[0])
+	}
 	recvbuf := unsafe.Pointer(&dest[0])
 	return Error(C.MPI_Scatter(sendbuf, C.int(len(dest)), C.COMPLEX128, recvbuf, C.int(len(dest)), C.COMPLEX128, C.int(fmProc), cm.comm), "GatherC128")
 }
@@ -821,10 +929,13 @@ func (cm *Comm) BcastC64(fmProc int, vals []complex64) error {
 }
 
 // ReduceC64 reduces all values across procs to toProc in orig to dest using given operation.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ReduceC64(toProc int, op Op, dest, orig []complex64) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Reduce(sendbuf, recvbuf, C.int(len(dest)), C.COMPLEX64, op.ToC(), C.int(toProc), cm.comm), "ReduceC64")
 }
 
@@ -838,10 +949,13 @@ func (cm *Comm) AllReduceC64(op Op, dest, orig []complex64) error {
 
 // GatherC64 gathers values from all procs into toProc proc, tiled into dest of size np * len(orig).
 // This is inverse of Scatter.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices.
 func (cm *Comm) GatherC64(toProc int, dest, orig []complex64) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Gather(sendbuf, C.int(len(orig)), C.COMPLEX64, recvbuf, C.int(len(orig)), C.COMPLEX64, C.int(toProc), cm.comm), "GatherC64")
 }
 
@@ -856,9 +970,12 @@ func (cm *Comm) AllGatherC64(dest, orig []complex64) error {
 
 // ScatterC64 scatters values from fmProc to all procs, distributing len(dest) size chunks to
 // each proc from orig slice, which must be of size np * len(dest).  This is inverse of Gather.
+// sendbuf is ignored on all procs except fmProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) ScatterC64(fmProc int, dest, orig []complex64) error {
-	sendbuf := unsafe.Pointer(&orig[0])
+	if sendbuf != nil {
+		sendbuf := unsafe.Pointer(&orig[0])
+	}
 	recvbuf := unsafe.Pointer(&dest[0])
 	return Error(C.MPI_Scatter(sendbuf, C.int(len(dest)), C.COMPLEX64, recvbuf, C.int(len(dest)), C.COMPLEX64, C.int(fmProc), cm.comm), "GatherC64")
 }

--- a/mpi/numeric.gen.go.tmpl
+++ b/mpi/numeric.gen.go.tmpl
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build mpi
+//go:build mpi
 
 package mpi
 
@@ -55,10 +55,13 @@ func (cm *Comm) Bcast{{.Name}}(fmProc int, vals []{{or .Type}}) error {
 }
 
 // Reduce{{.Name}} reduces all values across procs to toProc in orig to dest using given operation.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) Reduce{{.Name}}(toProc int, op Op, dest, orig []{{or .Type}}) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Reduce(sendbuf, recvbuf, C.int(len(dest)), C.{{or .CType}}, op.ToC(), C.int(toProc), cm.comm), "Reduce{{.Name}}")
 }
 
@@ -72,10 +75,13 @@ func (cm *Comm) AllReduce{{.Name}}(op Op, dest, orig []{{or .Type}}) error {
 
 // Gather{{.Name}} gathers values from all procs into toProc proc, tiled into dest of size np * len(orig).
 // This is inverse of Scatter.
+// recvbuf is ignored on all procs except toProc.
 // IMPORTANT: orig and dest must be different slices.
 func (cm *Comm) Gather{{.Name}}(toProc int, dest, orig []{{or .Type}}) error {
 	sendbuf := unsafe.Pointer(&orig[0])
-	recvbuf := unsafe.Pointer(&dest[0])
+	if recvbuf != nil {
+		recvbuf := unsafe.Pointer(&dest[0])
+	}
 	return Error(C.MPI_Gather(sendbuf, C.int(len(orig)), C.{{or .CType}}, recvbuf, C.int(len(orig)), C.{{or .CType}}, C.int(toProc), cm.comm), "Gather{{.Name}}")
 }
 
@@ -90,9 +96,12 @@ func (cm *Comm) AllGather{{.Name}}(dest, orig []{{or .Type}}) error {
 
 // Scatter{{.Name}} scatters values from fmProc to all procs, distributing len(dest) size chunks to
 // each proc from orig slice, which must be of size np * len(dest).  This is inverse of Gather.
+// sendbuf is ignored on all procs except fmProc.
 // IMPORTANT: orig and dest must be different slices
 func (cm *Comm) Scatter{{.Name}}(fmProc int, dest, orig []{{or .Type}}) error {
-	sendbuf := unsafe.Pointer(&orig[0])
+	if sendbuf != nil {
+		sendbuf := unsafe.Pointer(&orig[0])
+	}
 	recvbuf := unsafe.Pointer(&dest[0])
 	return Error(C.MPI_Scatter(sendbuf, C.int(len(dest)), C.{{or .CType}}, recvbuf, C.int(len(dest)), C.{{or .CType}}, C.int(fmProc), cm.comm), "Gather{{.Name}}")
 }


### PR DESCRIPTION
Example, see https://www.mpich.org/static/docs/v3.3/www3/MPI_Gather.html
```
recvbuf
  address of receive buffer (choice, significant only at root)
```
