### PR TITLE
v1.0.18 release -- version.go updated

### DIFF
--- a/empi/Makefile
+++ b/empi/Makefile
@@ -17,7 +17,7 @@ clean:
 	$(GOCLEAN)
 
 # NOTE: MUST update version number here prior to running 'make release'
-VERS=v1.0.17
+VERS=v1.0.18
 PACKAGE=empi
 GIT_COMMIT=`git rev-parse --short HEAD`
 VERS_DATE=`date -u +%Y-%m-%d\ %H:%M`


### PR DESCRIPTION
I edited the empi/Makefile and then ran `make release`.